### PR TITLE
Context node in constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-module.exports = function(selector) {
-  var nodes = selector.nodeName || selector === window ? [selector] : document.querySelectorAll(selector)
+module.exports = function(selector, context) {
+  context = context || document
+  var nodes = selector.nodeName || selector === window ? [selector] : context.querySelectorAll(selector)
 
   if (nodes.length === 0) return null
 

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ var setup = function(name) {
   var div = document.createElement('div')
   div.className = name
   document.body.appendChild(div)
+  return div
 }
 var teardown = function(name) {
   $('.'+name).each(function(node) {
@@ -227,6 +228,20 @@ var testDocumentClick = function() {
 var testWindow = function() {
   $(window) // will fail if it doesn't work
 }
+var testContext = function() {
+  setup('testContext')
+  var outer = setup('testContextOuter')
+  var div = document.createElement('div')
+  div.className = 'testContext'
+  outer.appendChild(div)
+
+  equals(2, $('.testContext').length)
+  equals(2, $('.testContext', document.body).length)
+  equals(1, $('.testContext', outer).length)
+
+  teardown('testContext')
+  teardown('testContextOuter')
+}
 
 testThreeElements()
 testSingleElement()
@@ -247,3 +262,4 @@ testDocument()
 testNodes()
 testDocumentClick()
 testWindow()
+testContext()


### PR DESCRIPTION
Allow to pass a context node in constructor. Defaults to `document`.
