### PR TITLE
join with '' instead of ' '

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ module.exports = function(selector, context) {
   nodes.removeClass = function(name) {
     return nodes.forEach(function(node) {
       if (node.className.indexOf(name) === -1) return
-      node.className = node.className.split(name).join(' ')
+      node.className = node.className.split(name).join('')
     })
   }
   nodes.toggleClass = function(name, state) {

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ module.exports = function(selector, context) {
   nodes.removeClass = function(name) {
     return nodes.forEach(function(node) {
       if (node.className.indexOf(name) === -1) return
-      node.className = node.className.split(name).join('')
+      node.className = node.className.split(name).join()
     })
   }
   nodes.toggleClass = function(name, state) {


### PR DESCRIPTION
When removing a class `node.className` would inadvertently get extra spaces in the name due to `join(' ')`
